### PR TITLE
Avoid wasting the storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 mysqldata:
-  image: busybox
+  image: mysql
   volumes:
    - /var/lib/mysql
 mysqld:


### PR DESCRIPTION
In general, there is no reason to create a data container out of
a different image from the DB's.

You might have intended to reduce the footprint by using a minimal
image such as busybox, but thanks to Docker's architecture
you would get an adverse result.
